### PR TITLE
Refactor CMakeLists.txt for AESDK library setup

### DIFF
--- a/AfterEffectsSDK/CMakeLists.txt
+++ b/AfterEffectsSDK/CMakeLists.txt
@@ -1,7 +1,22 @@
 project(AfterEffectsSDK)
 
+add_library(${PROJECT_NAME} STATIC)
+
+if(WIN32)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE _WINDOWS=1)
+endif()
+
+# Suppress warnings for this library across different compilers
+if(MSVC)
+  # For Microsoft Visual C++
+  target_compile_options(${PROJECT_NAME} PRIVATE /W0)
+else()
+  # For GCC, Clang, etc.
+  target_compile_options(${PROJECT_NAME} PRIVATE -w)
+endif()
+
 # source files
-set(SOURCE_FILES
+target_sources(${PROJECT_NAME} PRIVATE
   "Util/AEFX_ArbParseHelper.c"
   "Util/AEFX_SuiteHelper.c"
   "Util/AEGP_SuiteHandler.cpp"
@@ -14,14 +29,28 @@ set(SOURCE_FILES
   # "Util/String_Utils.c"
 )
 
-add_library(AfterEffectsSDK STATIC ${SOURCE_FILES})
-
 # headers
-target_include_directories(AfterEffectsSDK PUBLIC
-  "Headers"
-  "Headers/SP"
-  "Util"
-  "Resources"
-  "GPUUtils"
-  "GPUUtils/PrGPU/KernelSupport"
+target_include_directories(${PROJECT_NAME} 
+  SYSTEM PUBLIC
+    FILE_SET HEADERS
+      BASE_DIRS
+        "Headers"
+        "Headers/SP"
+        "Util"
+        "Resources"
+        "GPUUtils"
+        "GPUUtils/PrGPU/KernelSupport"
+      FILES
+        "Headers/AEConfig.h"
+        "Headers/AE_Effect.h"
+        "Headers/AE_EffectCB.h"
+        "Headers/AE_EffectCBSuites.h"
+        "Headers/AE_Macros.h"
+        "Util/entry.h"
+        "Util/AEGP_SuiteHandler.h"
+        "Util/Param_Utils.h"
+        "Util/Smart_Utils.h"
+
+        # This header is not completed
+        # "Util/String_Utils.h"
 )

--- a/AfterEffectsSDK/CMakeLists.txt
+++ b/AfterEffectsSDK/CMakeLists.txt
@@ -7,6 +7,7 @@ if(WIN32)
 endif()
 
 # Suppress warnings for this library across different compilers
+# For reason: This SDK is written in a old way and may produce warnings
 if(MSVC)
   # For Microsoft Visual C++
   target_compile_options(${PROJECT_NAME} PRIVATE /W0)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18.2)
+cmake_minimum_required(VERSION 3.22)
 
 project("AEVE_Plugins")
 


### PR DESCRIPTION
Streamline the library setup in CMakeLists.txt for the AfterEffectsSDK, including suppression of compiler warnings across different platforms.