### PR TITLE
Enable FsTouchDrawCenter in build process and update source files

### DIFF
--- a/Source/Effects/FsTouchDrawCenter/CMakeLists.txt
+++ b/Source/Effects/FsTouchDrawCenter/CMakeLists.txt
@@ -3,9 +3,13 @@ project("TouchDrawCenter")
 # Set the plugin specific source files
 set(${PROJECT_NAME}_SOURCES
   TouchDrawCenter.cpp
+  ToutchDraw8.cpp
   ToutchDraw16.cpp
   ToutchDraw32.cpp
-  ToutchDraw8.cpp
+  alphaBlur8.cpp
+  alphaBlur16.cpp
+  alphaBlur32.cpp
+  copyImage.cpp
 )
 
 # Call the common plugin build function

--- a/Source/Effects/FsTouchDrawCenter/TouchDrawCenter.cpp
+++ b/Source/Effects/FsTouchDrawCenter/TouchDrawCenter.cpp
@@ -1,7 +1,5 @@
-
 // clang-format off
 #include "TouchDrawCenter.h"
-#include "Fs_Entry.h"
 // clang-format on
 
 // Pass parameters to After Effects
@@ -347,3 +345,7 @@ static PF_Err SmartRender(PF_InData* in_data, PF_OutData* out_data,
   return err;
 }
 #endif
+
+// clang-format off
+#include "Fs_Entry.h"
+// clang-format on

--- a/prev-build-process.cmake
+++ b/prev-build-process.cmake
@@ -263,7 +263,7 @@ add_subdirectory("Source/Effects/FsToGray")
 add_subdirectory("Source/Effects/FsTone")
 add_subdirectory("Source/Effects/FsToner")
 # add_subdirectory("Source/Effects/FsTouchDraw") # Link error
-# add_subdirectory("Source/Effects/FsTouchDrawCenter") # Link error
+add_subdirectory("Source/Effects/FsTouchDrawCenter")
 # add_subdirectory("Source/Effects/FsTouchDrawStraght") # Link error
 # add_subdirectory("Source/Effects/FsUnmult_KNSW_Fake") # Compile error
 # add_subdirectory("Source/Effects/FsUnmult_RG_Fake") # Compile error


### PR DESCRIPTION
Update the CMakeLists.txt to include additional source files for the FsTouchDrawCenter effect and enable its inclusion in the build process. Adjustments to the TouchDrawCenter.cpp file ensure proper header inclusion.